### PR TITLE
Added Endpoint for Individual Review

### DIFF
--- a/src/main/java/edu/ucsb/cs156/dining/controllers/ReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/dining/controllers/ReviewController.java
@@ -213,4 +213,21 @@ public class ReviewController extends ApiController {
         Iterable<Review> reviewsList = reviewRepository.findByStatus(ModerationStatus.AWAITING_REVIEW);
         return reviewsList;
     }
+
+
+    @Operation(summary = "Get a review by id")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/get")
+    public Review getReviewById(@Parameter Long id) {
+        Review review = reviewRepository.findById(id).orElseThrow(
+                () -> new EntityNotFoundException(Review.class, id)
+        );
+        User current = getCurrentUser().getUser();
+        // Note: Once moderator is implmented, we can change this, and add another check for if user is a moderator
+        // and if the review is moderated
+        if (current.getId() != review.getReviewer().getId() && !current.getAdmin()) {
+            throw new AccessDeniedException("Only the user who made this review or an admin can get id");
+        }
+        return review;
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/dining/controllers/ReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/dining/controllers/ReviewController.java
@@ -228,6 +228,8 @@ public class ReviewController extends ApiController {
         if (current.getId() != review.getReviewer().getId() && !current.getAdmin()) {
             throw new AccessDeniedException("Only the user who made this review or an admin can get id");
         }
+
+
         return review;
     }
 }

--- a/src/test/java/edu/ucsb/cs156/dining/controllers/ReviewControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/controllers/ReviewControllerTests.java
@@ -991,6 +991,115 @@ public class ReviewControllerTests extends ControllerTestCase {
         assertEquals(expectedJson,responseJson);
     }
 
+    // Reviewer can access
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void testReviewerCanGetID() throws Exception {
+        User user = currentUserService.getUser();
+        MenuItem menuItem = MenuItem.builder().id(1L).build();
+
+        Review review = Review.builder()
+                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+                .reviewer(user)
+                .status(ModerationStatus.APPROVED)
+                .item(menuItem)
+                .id(1L)
+                .build();
+
+        when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review));
+
+        MvcResult response = mockMvc.perform(get("/api/reviews/get")
+                        .param("id", "1")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andReturn();
+        
+        verify(reviewRepository, times(1)).findById(eq(1L));
+        String expectedJson = mapper.writeValueAsString(review);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+
+    }
+
+    // Admin can access review 
+    @WithMockUser(roles = {"ADMIN","USER"})
+    @Test
+    public void testAdminCanGetID() throws Exception {
+        User user2 = User.builder().id(2L).build();
+        MenuItem menuItem = MenuItem.builder().id(1L).build();
+
+        Review review = Review.builder()
+                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+                .reviewer(user2)
+                .status(ModerationStatus.APPROVED)
+                .item(menuItem)
+                .id(1L)
+                .build();
+
+        when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review));
+
+        MvcResult response = mockMvc.perform(get("/api/reviews/get")
+                        .param("id", "1")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        verify(reviewRepository, times(1)).findById(eq(1L));
+        String expectedJson = mapper.writeValueAsString(review);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
 
 
+    }
+
+
+    // Unauthorized user (not reviewer or admin) is denied
+    public void unauthorizedUserDenied() throws Exception{
+        User user = currentUserService.getUser();
+        User user2 = User.builder().id(2L).build();
+        MenuItem menuItem = MenuItem.builder().id(1L).build();
+
+        Review review = Review.builder()
+                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+                .reviewer(user2)
+                .status(ModerationStatus.APPROVED)
+                .item(menuItem)
+                .id(1L)
+                .build();
+
+        when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review));
+
+        MvcResult response = mockMvc.perform(get("/api/reviews/get")
+                        .param("id", "1")
+                        .with(csrf()))
+                .andExpect(status().isForbidden())
+                .andReturn();
+    }
+    
+    
+    // Review not found
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void testGetReviewById_NotFound() throws Exception {
+        when(reviewRepository.findById(eq(1L))).thenReturn(Optional.empty());
+
+        MvcResult response = mockMvc.perform(get("/api/reviews/get")
+                        .param("id", "1")
+                        .with(csrf()))
+                .andExpect(status().isNotFound())
+                .andReturn();
+
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("Review with id 1 not found", json.get("message"));
+    }
 }
+
+
+
+

--- a/src/test/java/edu/ucsb/cs156/dining/controllers/ReviewControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/controllers/ReviewControllerTests.java
@@ -1058,8 +1058,9 @@ public class ReviewControllerTests extends ControllerTestCase {
 
 
     // Unauthorized user (not reviewer or admin) is denied
+    @WithMockUser(roles = {"USER"})
+    @Test
     public void unauthorizedUserDenied() throws Exception{
-        User user = currentUserService.getUser();
         User user2 = User.builder().id(2L).build();
         MenuItem menuItem = MenuItem.builder().id(1L).build();
 


### PR DESCRIPTION
Closes #10

Added an individual review endpoint on swagger so that a user can look up a review by ID. Only the user who made the review or an admin can do so. (Note for future development: Once moderators are properly implemented, make this functionality available for moderators as well). 

This feature can be checked by navigating to [my dokku site](https://dining-proj-jw.dokku-04.cs.ucsb.edu/), clicking swagger, and testing it as follows: 
<img width="1453" alt="Screenshot 2025-05-19 at 4 24 44 PM" src="https://github.com/user-attachments/assets/831ad742-481e-4ace-84f6-e8fdae06640d" />
