### PR TITLE
Add Individual Review page

### DIFF
--- a/frontend/src/main/pages/Reviews/ReviewsForMenuItemPage.js
+++ b/frontend/src/main/pages/Reviews/ReviewsForMenuItemPage.js
@@ -10,7 +10,7 @@ export default function ReviewsForMenuItemPage() {
     // Stryker disable next-line all: don't test internal caching of React Query
     ["reviewsForMenuItem", itemid],
     // Stryker disable next-line all: default method is get, so replacing with an empty string will do nothing
-    { method: "GET", url: `/api/diningcommons/menuitem?id=${itemid}` }
+    { method: "GET", url: `/api/diningcommons/menuitem?id=${itemid}` },
     // no initial data
   );
 
@@ -36,7 +36,7 @@ export default function ReviewsForMenuItemPage() {
     (Array.isArray(data?.reviews) ? data.reviews : []).filter(
       (review) =>
         review.reviewerComments !== null &&
-        review.reviewerComments !== undefined
+        review.reviewerComments !== undefined,
     );
 
   return (

--- a/frontend/src/main/pages/Reviews/ReviewsForMenuItemPage.js
+++ b/frontend/src/main/pages/Reviews/ReviewsForMenuItemPage.js
@@ -11,7 +11,6 @@ export default function ReviewsForMenuItemPage() {
     ["reviewsForMenuItem", itemid],
     // Stryker disable next-line all: default method is get, so replacing with an empty string will do nothing
     { method: "GET", url: `/api/diningcommons/menuitem?id=${itemid}` },
-    // no initial data
   );
 
   if (isLoading) {

--- a/frontend/src/main/pages/Reviews/ReviewsForMenuItemPage.js
+++ b/frontend/src/main/pages/Reviews/ReviewsForMenuItemPage.js
@@ -1,13 +1,52 @@
 import React from "react";
 import { useParams } from "react-router-dom";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import ReviewTable from "main/components/Reviews/ReviewTable";
+import { useBackend } from "main/utils/useBackend";
 
 export default function ReviewsForMenuItemPage() {
   const { itemid } = useParams();
+  const { data, isLoading, error } = useBackend(
+    // Stryker disable next-line all: don't test internal caching of React Query
+    ["reviewsForMenuItem", itemid],
+    // Stryker disable next-line all: default method is get, so replacing with an empty string will do nothing
+    { method: "GET", url: `/api/diningcommons/menuitem?id=${itemid}` }
+    // no initial data
+  );
+
+  if (isLoading) {
+    return (
+      <BasicLayout>
+        <p>Loading...</p>
+      </BasicLayout>
+    );
+  }
+
+  // Stryker disable next-line all : Don't mutate error block
+  if (error) {
+    return (
+      <BasicLayout>
+        <p>Error loading reviews.</p>
+      </BasicLayout>
+    );
+  }
+
+  const filteredReviews =
+    // Stryker disable next-line ArrayDeclaration : Don't mutate fallback array
+    (Array.isArray(data?.reviews) ? data.reviews : []).filter(
+      (review) =>
+        review.reviewerComments !== null &&
+        review.reviewerComments !== undefined
+    );
+
   return (
     <BasicLayout>
       <h1>Reviews for Menu Item {itemid}</h1>
-      <p>Coming Soon!</p>
+      <ReviewTable
+        data={filteredReviews}
+        userOptions={false}
+        moderatorOptions={false}
+      />
     </BasicLayout>
   );
 }

--- a/frontend/src/stories/pages/Reviews/ReviewsForMenuItemPage.stories.js
+++ b/frontend/src/stories/pages/Reviews/ReviewsForMenuItemPage.stories.js
@@ -1,11 +1,33 @@
 import React from "react";
+import { http, HttpResponse } from "msw";
 import ReviewsForMenuItemPage from "main/pages/Reviews/ReviewsForMenuItemPage";
 import { reactRouterParameters } from "storybook-addon-remix-react-router";
+import { ReviewFixtures } from "fixtures/reviewFixtures";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 
 export default {
   title: "pages/Reviews/ReviewsForMenuItemPage",
   component: ReviewsForMenuItemPage,
   parameters: {
+    msw: [
+      http.get("/api/diningcommons/menuitem", ({ request }) => {
+        const url = new URL(request.url);
+        if (url.searchParams.get("id") === "42") {
+          return HttpResponse.json(
+            { reviews: ReviewFixtures.threeReviews },
+            { status: 200 }
+          );
+        }
+        return HttpResponse.json({ reviews: [] }, { status: 200 });
+      }),
+      http.get("/api/currentUser", () => {
+        return HttpResponse.json(apiCurrentUserFixtures.userOnly);
+      }),
+      http.get("/api/systemInfo", () => {
+        return HttpResponse.json(systemInfoFixtures.showingNeither);
+      }),
+    ],
     reactRouter: reactRouterParameters({
       location: {
         pathParams: {

--- a/frontend/src/stories/pages/Reviews/ReviewsForMenuItemPage.stories.js
+++ b/frontend/src/stories/pages/Reviews/ReviewsForMenuItemPage.stories.js
@@ -16,7 +16,7 @@ export default {
         if (url.searchParams.get("id") === "42") {
           return HttpResponse.json(
             { reviews: ReviewFixtures.threeReviews },
-            { status: 200 }
+            { status: 200 },
           );
         }
         return HttpResponse.json({ reviews: [] }, { status: 200 });

--- a/frontend/src/tests/components/MenuItem/MenuItemTable.test.js
+++ b/frontend/src/tests/components/MenuItem/MenuItemTable.test.js
@@ -32,26 +32,26 @@ describe("MenuItemTable Tests", () => {
           menuItems={[]}
           currentUser={currentUserFixtures.notLoggedIn}
         />
-      </MemoryRouter>,
+      </MemoryRouter>
     );
 
     expect(screen.getByTestId("MenuItemTable-header-name")).toHaveTextContent(
-      "Item Name",
+      "Item Name"
     );
     expect(
-      screen.getByTestId("MenuItemTable-header-station"),
+      screen.getByTestId("MenuItemTable-header-station")
     ).toHaveTextContent("Station");
     expect(screen.getByTestId("MenuItemTable-header-id")).toHaveTextContent(
-      "Reviews",
+      "Reviews"
     );
     expect(
-      screen.queryByTestId("MenuItemTable-row-cell-0-col-name"),
+      screen.queryByTestId("MenuItemTable-row-cell-0-col-name")
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByTestId("MenuItemTable-row-cell-0-col-station"),
+      screen.queryByTestId("MenuItemTable-row-cell-0-col-station")
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByTestId("MenuItemTable-cell-row-0-col-Review Item-button"),
+      screen.queryByTestId("MenuItemTable-cell-row-0-col-Review Item-button")
     ).not.toBeInTheDocument();
   });
   test("Renders 5 Menu Items Correctly and Reviews link is correct", async () => {
@@ -62,24 +62,24 @@ describe("MenuItemTable Tests", () => {
           menuItems={fiveMenuItems}
           currentUser={currentUserFixtures.notLoggedIn}
         />
-      </MemoryRouter>,
+      </MemoryRouter>
     );
 
     for (let i = 0; i < fiveMenuItems.length; i++) {
       expect(
-        screen.getByTestId(`MenuItemTable-cell-row-${i}-col-name`),
+        screen.getByTestId(`MenuItemTable-cell-row-${i}-col-name`)
       ).toHaveTextContent(fiveMenuItems[i].name);
       expect(
-        screen.getByTestId(`MenuItemTable-cell-row-${i}-col-station`),
+        screen.getByTestId(`MenuItemTable-cell-row-${i}-col-station`)
       ).toHaveTextContent(fiveMenuItems[i].station);
       const reviewsCell = screen.getByTestId(
-        `MenuItemTable-cell-row-${i}-col-id`,
+        `MenuItemTable-cell-row-${i}-col-id`
       );
       const link = within(reviewsCell).getByRole("link", { name: "Reviews" });
       expect(link).toHaveTextContent("Reviews");
       expect(link).toHaveAttribute("href", `/reviews/${fiveMenuItems[i].id}`);
       expect(
-        screen.queryByTestId("MenuItemTable-cell-row-0-col-Review Item-button"),
+        screen.queryByTestId("MenuItemTable-cell-row-0-col-Review Item-button")
       ).not.toBeInTheDocument();
     }
   });
@@ -98,10 +98,10 @@ describe("MenuItemTable Tests", () => {
           menuItems={menuItemFixtures.oneMenuItem}
           currentUser={currentUserFixtures.userOnly}
         />
-      </MemoryRouter>,
+      </MemoryRouter>
     );
     let button = screen.getByTestId(
-      "MenuItemTable-cell-row-0-col-Review Item-button",
+      "MenuItemTable-cell-row-0-col-Review Item-button"
     );
     expect(button).toBeInTheDocument();
     expect(button).toHaveClass("btn-warning");
@@ -120,10 +120,10 @@ describe("MenuItemTable Tests", () => {
           menuItems={menuItemFixtures.oneMenuItem}
           currentUser={currentUserFixtures.notLoggedIn}
         />
-      </MemoryRouter>,
+      </MemoryRouter>
     );
     expect(
-      screen.queryByTestId("MenuItemTable-cell-row-0-col-Review Item-button"),
+      screen.queryByTestId("MenuItemTable-cell-row-0-col-Review Item-button")
     ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/components/MenuItem/MenuItemTable.test.js
+++ b/frontend/src/tests/components/MenuItem/MenuItemTable.test.js
@@ -32,26 +32,26 @@ describe("MenuItemTable Tests", () => {
           menuItems={[]}
           currentUser={currentUserFixtures.notLoggedIn}
         />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     expect(screen.getByTestId("MenuItemTable-header-name")).toHaveTextContent(
-      "Item Name"
+      "Item Name",
     );
     expect(
-      screen.getByTestId("MenuItemTable-header-station")
+      screen.getByTestId("MenuItemTable-header-station"),
     ).toHaveTextContent("Station");
     expect(screen.getByTestId("MenuItemTable-header-id")).toHaveTextContent(
-      "Reviews"
+      "Reviews",
     );
     expect(
-      screen.queryByTestId("MenuItemTable-row-cell-0-col-name")
+      screen.queryByTestId("MenuItemTable-row-cell-0-col-name"),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByTestId("MenuItemTable-row-cell-0-col-station")
+      screen.queryByTestId("MenuItemTable-row-cell-0-col-station"),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByTestId("MenuItemTable-cell-row-0-col-Review Item-button")
+      screen.queryByTestId("MenuItemTable-cell-row-0-col-Review Item-button"),
     ).not.toBeInTheDocument();
   });
   test("Renders 5 Menu Items Correctly and Reviews link is correct", async () => {
@@ -62,24 +62,24 @@ describe("MenuItemTable Tests", () => {
           menuItems={fiveMenuItems}
           currentUser={currentUserFixtures.notLoggedIn}
         />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     for (let i = 0; i < fiveMenuItems.length; i++) {
       expect(
-        screen.getByTestId(`MenuItemTable-cell-row-${i}-col-name`)
+        screen.getByTestId(`MenuItemTable-cell-row-${i}-col-name`),
       ).toHaveTextContent(fiveMenuItems[i].name);
       expect(
-        screen.getByTestId(`MenuItemTable-cell-row-${i}-col-station`)
+        screen.getByTestId(`MenuItemTable-cell-row-${i}-col-station`),
       ).toHaveTextContent(fiveMenuItems[i].station);
       const reviewsCell = screen.getByTestId(
-        `MenuItemTable-cell-row-${i}-col-id`
+        `MenuItemTable-cell-row-${i}-col-id`,
       );
       const link = within(reviewsCell).getByRole("link", { name: "Reviews" });
       expect(link).toHaveTextContent("Reviews");
       expect(link).toHaveAttribute("href", `/reviews/${fiveMenuItems[i].id}`);
       expect(
-        screen.queryByTestId("MenuItemTable-cell-row-0-col-Review Item-button")
+        screen.queryByTestId("MenuItemTable-cell-row-0-col-Review Item-button"),
       ).not.toBeInTheDocument();
     }
   });
@@ -98,10 +98,10 @@ describe("MenuItemTable Tests", () => {
           menuItems={menuItemFixtures.oneMenuItem}
           currentUser={currentUserFixtures.userOnly}
         />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
     let button = screen.getByTestId(
-      "MenuItemTable-cell-row-0-col-Review Item-button"
+      "MenuItemTable-cell-row-0-col-Review Item-button",
     );
     expect(button).toBeInTheDocument();
     expect(button).toHaveClass("btn-warning");
@@ -120,10 +120,10 @@ describe("MenuItemTable Tests", () => {
           menuItems={menuItemFixtures.oneMenuItem}
           currentUser={currentUserFixtures.notLoggedIn}
         />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
     expect(
-      screen.queryByTestId("MenuItemTable-cell-row-0-col-Review Item-button")
+      screen.queryByTestId("MenuItemTable-cell-row-0-col-Review Item-button"),
     ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/pages/Reviews/ReviewsForMenuItemPage.test.js
+++ b/frontend/src/tests/pages/Reviews/ReviewsForMenuItemPage.test.js
@@ -16,7 +16,7 @@ function renderWithProviders(route = "/reviews/42") {
           <Route path="/reviews/:itemid" element={<ReviewsForMenuItemPage />} />
         </Routes>
       </MemoryRouter>
-    </QueryClientProvider>
+    </QueryClientProvider>,
   );
 }
 
@@ -78,7 +78,7 @@ describe("ReviewsForMenuItemPage", () => {
       .reply(200, apiCurrentUserFixtures.userOnly);
     renderWithProviders();
     expect(
-      await screen.findByText("Reviews for Menu Item 42")
+      await screen.findByText("Reviews for Menu Item 42"),
     ).toBeInTheDocument();
     expect(await screen.findByText("Great!")).toBeInTheDocument();
     expect(await screen.findByText("Yum!")).toBeInTheDocument();
@@ -103,7 +103,7 @@ describe("ReviewsForMenuItemPage", () => {
       .reply(200, apiCurrentUserFixtures.userOnly);
     renderWithProviders();
     expect(
-      await screen.findByText("Reviews for Menu Item 42")
+      await screen.findByText("Reviews for Menu Item 42"),
     ).toBeInTheDocument();
     const table = await screen.findByRole("table");
     const rows = within(table).getAllByRole("row");
@@ -124,7 +124,7 @@ describe("ReviewsForMenuItemPage", () => {
       .reply(200, apiCurrentUserFixtures.userOnly);
     renderWithProviders();
     expect(
-      await screen.findByText("Reviews for Menu Item 42")
+      await screen.findByText("Reviews for Menu Item 42"),
     ).toBeInTheDocument();
     const table = await screen.findByRole("table");
     const rows = within(table).getAllByRole("row");
@@ -147,19 +147,19 @@ describe("ReviewsForMenuItemPage", () => {
       .reply(200, apiCurrentUserFixtures.userOnly);
     renderWithProviders();
     expect(
-      await screen.findByText("Reviews for Menu Item 42")
+      await screen.findByText("Reviews for Menu Item 42"),
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Edit" })
+      screen.queryByRole("button", { name: "Edit" }),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Delete" })
+      screen.queryByRole("button", { name: "Delete" }),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Approve" })
+      screen.queryByRole("button", { name: "Approve" }),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Reject" })
+      screen.queryByRole("button", { name: "Reject" }),
     ).not.toBeInTheDocument();
   });
 
@@ -202,16 +202,16 @@ describe("ReviewsForMenuItemPage", () => {
             />
           </Routes>
         </MemoryRouter>
-      </QueryClientProvider>
+      </QueryClientProvider>,
     );
     expect(
-      await screen.findByText("Reviews for Menu Item 42")
+      await screen.findByText("Reviews for Menu Item 42"),
     ).toBeInTheDocument();
     expect(
-      screen.getByTestId("ReviewTable-cell-row-0-col-itemId")
+      screen.getByTestId("ReviewTable-cell-row-0-col-itemId"),
     ).toHaveTextContent("42");
     expect(
-      screen.getByTestId("ReviewTable-cell-row-0-col-reviewerComments")
+      screen.getByTestId("ReviewTable-cell-row-0-col-reviewerComments"),
     ).toHaveTextContent("Great!");
     unmount();
     // Remount with itemid 99
@@ -225,16 +225,16 @@ describe("ReviewsForMenuItemPage", () => {
             />
           </Routes>
         </MemoryRouter>
-      </QueryClientProvider>
+      </QueryClientProvider>,
     );
     expect(
-      await screen.findByText("Reviews for Menu Item 99")
+      await screen.findByText("Reviews for Menu Item 99"),
     ).toBeInTheDocument();
     expect(
-      screen.getByTestId("ReviewTable-cell-row-0-col-itemId")
+      screen.getByTestId("ReviewTable-cell-row-0-col-itemId"),
     ).toHaveTextContent("99");
     expect(
-      screen.getByTestId("ReviewTable-cell-row-0-col-reviewerComments")
+      screen.getByTestId("ReviewTable-cell-row-0-col-reviewerComments"),
     ).toHaveTextContent("Meh!");
   });
 
@@ -276,16 +276,16 @@ describe("ReviewsForMenuItemPage", () => {
             />
           </Routes>
         </MemoryRouter>
-      </QueryClientProvider>
+      </QueryClientProvider>,
     );
     expect(
-      await screen.findByText("Reviews for Menu Item 101")
+      await screen.findByText("Reviews for Menu Item 101"),
     ).toBeInTheDocument();
     expect(
-      await screen.findByTestId("ReviewTable-cell-row-0-col-itemId")
+      await screen.findByTestId("ReviewTable-cell-row-0-col-itemId"),
     ).toHaveTextContent("101");
     expect(
-      await screen.findByTestId("ReviewTable-cell-row-0-col-reviewerComments")
+      await screen.findByTestId("ReviewTable-cell-row-0-col-reviewerComments"),
     ).toHaveTextContent("First!");
     unmount();
     // Remount with itemid 202
@@ -299,16 +299,16 @@ describe("ReviewsForMenuItemPage", () => {
             />
           </Routes>
         </MemoryRouter>
-      </QueryClientProvider>
+      </QueryClientProvider>,
     );
     expect(
-      await screen.findByText("Reviews for Menu Item 202")
+      await screen.findByText("Reviews for Menu Item 202"),
     ).toBeInTheDocument();
     expect(
-      await screen.findByTestId("ReviewTable-cell-row-0-col-itemId")
+      await screen.findByTestId("ReviewTable-cell-row-0-col-itemId"),
     ).toHaveTextContent("202");
     expect(
-      await screen.findByTestId("ReviewTable-cell-row-0-col-reviewerComments")
+      await screen.findByTestId("ReviewTable-cell-row-0-col-reviewerComments"),
     ).toHaveTextContent("Second!");
   });
 
@@ -322,7 +322,7 @@ describe("ReviewsForMenuItemPage", () => {
       .reply(200, apiCurrentUserFixtures.userOnly);
     renderWithProviders("/reviews/303");
     expect(
-      await screen.findByText("Reviews for Menu Item 303")
+      await screen.findByText("Reviews for Menu Item 303"),
     ).toBeInTheDocument();
     const table = screen.getByRole("table");
     const rows = within(table).getAllByRole("row");
@@ -339,7 +339,7 @@ describe("ReviewsForMenuItemPage", () => {
       .reply(200, apiCurrentUserFixtures.userOnly);
     renderWithProviders("/reviews/404");
     expect(
-      await screen.findByText("Reviews for Menu Item 404")
+      await screen.findByText("Reviews for Menu Item 404"),
     ).toBeInTheDocument();
     const table = screen.getByRole("table");
     const rows = within(table).getAllByRole("row");

--- a/frontend/src/tests/pages/Reviews/ReviewsForMenuItemPage.test.js
+++ b/frontend/src/tests/pages/Reviews/ReviewsForMenuItemPage.test.js
@@ -16,7 +16,7 @@ function renderWithProviders(route = "/reviews/42") {
           <Route path="/reviews/:itemid" element={<ReviewsForMenuItemPage />} />
         </Routes>
       </MemoryRouter>
-    </QueryClientProvider>,
+    </QueryClientProvider>
   );
 }
 
@@ -33,7 +33,7 @@ describe("ReviewsForMenuItemPage", () => {
     axiosMock
       .onGet("/api/systemInfo")
       .reply(200, systemInfoFixtures.showingNeither);
-    axiosMock.onGet("/api/diningcommons/menuitem?id=42").timeout(); // simulate loading state
+    axiosMock.onGet("/api/diningcommons/menuitem?id=42").timeout();
     axiosMock
       .onGet("/api/currentUser")
       .reply(200, apiCurrentUserFixtures.userOnly);
@@ -41,7 +41,6 @@ describe("ReviewsForMenuItemPage", () => {
     await waitFor(() => {
       expect(axiosMock.history.get.length).toBe(3);
     });
-    // Optionally, check that the table is not present
     expect(screen.queryByRole("table")).not.toBeInTheDocument();
   });
 
@@ -49,7 +48,7 @@ describe("ReviewsForMenuItemPage", () => {
     axiosMock
       .onGet("/api/systemInfo")
       .reply(200, systemInfoFixtures.showingNeither);
-    axiosMock.onGet("/api/diningcommons/menuitem?id=42").reply(500); // simulate error state
+    axiosMock.onGet("/api/diningcommons/menuitem?id=42").reply(500);
     axiosMock
       .onGet("/api/currentUser")
       .reply(200, apiCurrentUserFixtures.userOnly);
@@ -57,7 +56,6 @@ describe("ReviewsForMenuItemPage", () => {
     await waitFor(() => {
       expect(axiosMock.history.get.length).toBe(3);
     });
-    // Optionally, check that the table is not present
     expect(screen.queryByRole("table")).not.toBeInTheDocument();
   });
 
@@ -78,7 +76,7 @@ describe("ReviewsForMenuItemPage", () => {
       .reply(200, apiCurrentUserFixtures.userOnly);
     renderWithProviders();
     expect(
-      await screen.findByText("Reviews for Menu Item 42"),
+      await screen.findByText("Reviews for Menu Item 42")
     ).toBeInTheDocument();
     expect(await screen.findByText("Great!")).toBeInTheDocument();
     expect(await screen.findByText("Yum!")).toBeInTheDocument();
@@ -103,7 +101,7 @@ describe("ReviewsForMenuItemPage", () => {
       .reply(200, apiCurrentUserFixtures.userOnly);
     renderWithProviders();
     expect(
-      await screen.findByText("Reviews for Menu Item 42"),
+      await screen.findByText("Reviews for Menu Item 42")
     ).toBeInTheDocument();
     const table = await screen.findByRole("table");
     const rows = within(table).getAllByRole("row");
@@ -118,13 +116,13 @@ describe("ReviewsForMenuItemPage", () => {
     axiosMock
       .onGet("/api/systemInfo")
       .reply(200, systemInfoFixtures.showingNeither);
-    axiosMock.onGet("/api/diningcommons/menuitem?id=42").reply(200, null); // data is null
+    axiosMock.onGet("/api/diningcommons/menuitem?id=42").reply(200, null);
     axiosMock
       .onGet("/api/currentUser")
       .reply(200, apiCurrentUserFixtures.userOnly);
     renderWithProviders();
     expect(
-      await screen.findByText("Reviews for Menu Item 42"),
+      await screen.findByText("Reviews for Menu Item 42")
     ).toBeInTheDocument();
     const table = await screen.findByRole("table");
     const rows = within(table).getAllByRole("row");
@@ -147,19 +145,19 @@ describe("ReviewsForMenuItemPage", () => {
       .reply(200, apiCurrentUserFixtures.userOnly);
     renderWithProviders();
     expect(
-      await screen.findByText("Reviews for Menu Item 42"),
+      await screen.findByText("Reviews for Menu Item 42")
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Edit" }),
+      screen.queryByRole("button", { name: "Edit" })
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Delete" }),
+      screen.queryByRole("button", { name: "Delete" })
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Approve" }),
+      screen.queryByRole("button", { name: "Approve" })
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Reject" }),
+      screen.queryByRole("button", { name: "Reject" })
     ).not.toBeInTheDocument();
   });
 
@@ -191,7 +189,6 @@ describe("ReviewsForMenuItemPage", () => {
     });
 
     const queryClient = new QueryClient();
-    // Render with itemid 42
     const { unmount } = render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter initialEntries={["/reviews/42"]}>
@@ -202,19 +199,18 @@ describe("ReviewsForMenuItemPage", () => {
             />
           </Routes>
         </MemoryRouter>
-      </QueryClientProvider>,
+      </QueryClientProvider>
     );
     expect(
-      await screen.findByText("Reviews for Menu Item 42"),
+      await screen.findByText("Reviews for Menu Item 42")
     ).toBeInTheDocument();
     expect(
-      screen.getByTestId("ReviewTable-cell-row-0-col-itemId"),
+      screen.getByTestId("ReviewTable-cell-row-0-col-itemId")
     ).toHaveTextContent("42");
     expect(
-      screen.getByTestId("ReviewTable-cell-row-0-col-reviewerComments"),
+      screen.getByTestId("ReviewTable-cell-row-0-col-reviewerComments")
     ).toHaveTextContent("Great!");
     unmount();
-    // Remount with itemid 99
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter initialEntries={["/reviews/99"]}>
@@ -225,16 +221,16 @@ describe("ReviewsForMenuItemPage", () => {
             />
           </Routes>
         </MemoryRouter>
-      </QueryClientProvider>,
+      </QueryClientProvider>
     );
     expect(
-      await screen.findByText("Reviews for Menu Item 99"),
+      await screen.findByText("Reviews for Menu Item 99")
     ).toBeInTheDocument();
     expect(
-      screen.getByTestId("ReviewTable-cell-row-0-col-itemId"),
+      screen.getByTestId("ReviewTable-cell-row-0-col-itemId")
     ).toHaveTextContent("99");
     expect(
-      screen.getByTestId("ReviewTable-cell-row-0-col-reviewerComments"),
+      screen.getByTestId("ReviewTable-cell-row-0-col-reviewerComments")
     ).toHaveTextContent("Meh!");
   });
 
@@ -265,7 +261,6 @@ describe("ReviewsForMenuItemPage", () => {
       ],
     });
     const queryClient = new QueryClient();
-    // Render with itemid 101
     const { unmount } = render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter initialEntries={["/reviews/101"]}>
@@ -276,19 +271,18 @@ describe("ReviewsForMenuItemPage", () => {
             />
           </Routes>
         </MemoryRouter>
-      </QueryClientProvider>,
+      </QueryClientProvider>
     );
     expect(
-      await screen.findByText("Reviews for Menu Item 101"),
+      await screen.findByText("Reviews for Menu Item 101")
     ).toBeInTheDocument();
     expect(
-      await screen.findByTestId("ReviewTable-cell-row-0-col-itemId"),
+      await screen.findByTestId("ReviewTable-cell-row-0-col-itemId")
     ).toHaveTextContent("101");
     expect(
-      await screen.findByTestId("ReviewTable-cell-row-0-col-reviewerComments"),
+      await screen.findByTestId("ReviewTable-cell-row-0-col-reviewerComments")
     ).toHaveTextContent("First!");
     unmount();
-    // Remount with itemid 202
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter initialEntries={["/reviews/202"]}>
@@ -299,16 +293,16 @@ describe("ReviewsForMenuItemPage", () => {
             />
           </Routes>
         </MemoryRouter>
-      </QueryClientProvider>,
+      </QueryClientProvider>
     );
     expect(
-      await screen.findByText("Reviews for Menu Item 202"),
+      await screen.findByText("Reviews for Menu Item 202")
     ).toBeInTheDocument();
     expect(
-      await screen.findByTestId("ReviewTable-cell-row-0-col-itemId"),
+      await screen.findByTestId("ReviewTable-cell-row-0-col-itemId")
     ).toHaveTextContent("202");
     expect(
-      await screen.findByTestId("ReviewTable-cell-row-0-col-reviewerComments"),
+      await screen.findByTestId("ReviewTable-cell-row-0-col-reviewerComments")
     ).toHaveTextContent("Second!");
   });
 
@@ -322,7 +316,7 @@ describe("ReviewsForMenuItemPage", () => {
       .reply(200, apiCurrentUserFixtures.userOnly);
     renderWithProviders("/reviews/303");
     expect(
-      await screen.findByText("Reviews for Menu Item 303"),
+      await screen.findByText("Reviews for Menu Item 303")
     ).toBeInTheDocument();
     const table = screen.getByRole("table");
     const rows = within(table).getAllByRole("row");
@@ -339,7 +333,7 @@ describe("ReviewsForMenuItemPage", () => {
       .reply(200, apiCurrentUserFixtures.userOnly);
     renderWithProviders("/reviews/404");
     expect(
-      await screen.findByText("Reviews for Menu Item 404"),
+      await screen.findByText("Reviews for Menu Item 404")
     ).toBeInTheDocument();
     const table = screen.getByRole("table");
     const rows = within(table).getAllByRole("row");

--- a/frontend/src/tests/pages/Reviews/ReviewsForMenuItemPage.test.js
+++ b/frontend/src/tests/pages/Reviews/ReviewsForMenuItemPage.test.js
@@ -1,10 +1,24 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within, waitFor } from "@testing-library/react";
 import ReviewsForMenuItemPage from "../../../main/pages/Reviews/ReviewsForMenuItemPage";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "react-query";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 import { systemInfoFixtures } from "../../../fixtures/systemInfoFixtures";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+
+function renderWithProviders(route = "/reviews/42") {
+  const queryClient = new QueryClient();
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[route]}>
+        <Routes>
+          <Route path="/reviews/:itemid" element={<ReviewsForMenuItemPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
 
 describe("ReviewsForMenuItemPage", () => {
   let axiosMock;
@@ -14,12 +28,171 @@ describe("ReviewsForMenuItemPage", () => {
   afterEach(() => {
     axiosMock.reset();
   });
-  test("renders placeholder with correct itemid", () => {
+
+  test("shows loading state", async () => {
     axiosMock
       .onGet("/api/systemInfo")
       .reply(200, systemInfoFixtures.showingNeither);
+    axiosMock.onGet("/api/diningcommons/menuitem?id=42").timeout(); // simulate loading state
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    renderWithProviders();
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBe(3);
+    });
+    // Optionally, check that the table is not present
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+
+  test("shows error state", async () => {
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+    axiosMock.onGet("/api/diningcommons/menuitem?id=42").reply(500); // simulate error state
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    renderWithProviders();
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBe(3);
+    });
+    // Optionally, check that the table is not present
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+
+  test("filters out reviews with null comments", async () => {
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+    axiosMock.onGet("/api/diningcommons/menuitem?id=42").reply(200, {
+      reviews: [
+        { id: 1, itemId: 42, reviewerComments: "Great!" },
+        { id: 2, itemId: 42, reviewerComments: null },
+        { id: 3, itemId: 42, reviewerComments: undefined },
+        { id: 4, itemId: 42, reviewerComments: "Yum!" },
+      ],
+    });
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    renderWithProviders();
+    expect(
+      await screen.findByText("Reviews for Menu Item 42")
+    ).toBeInTheDocument();
+    expect(await screen.findByText("Great!")).toBeInTheDocument();
+    expect(await screen.findByText("Yum!")).toBeInTheDocument();
+    expect(screen.queryByText("null")).not.toBeInTheDocument();
+    expect(screen.queryByText("undefined")).not.toBeInTheDocument();
+  });
+
+  test("renders only reviews with non-null comments (row count)", async () => {
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+    axiosMock.onGet("/api/diningcommons/menuitem?id=42").reply(200, {
+      reviews: [
+        { id: 1, itemId: 42, reviewerComments: "Great!" },
+        { id: 2, itemId: 42, reviewerComments: null },
+        { id: 3, itemId: 42, reviewerComments: undefined },
+        { id: 4, itemId: 42, reviewerComments: "Yum!" },
+      ],
+    });
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    renderWithProviders();
+    expect(
+      await screen.findByText("Reviews for Menu Item 42")
+    ).toBeInTheDocument();
+    const table = await screen.findByRole("table");
+    const rows = within(table).getAllByRole("row");
+    expect(rows.length - 1).toBe(2);
+    expect(await screen.findByText("Great!")).toBeInTheDocument();
+    expect(await screen.findByText("Yum!")).toBeInTheDocument();
+    expect(screen.queryByText("null")).not.toBeInTheDocument();
+    expect(screen.queryByText("undefined")).not.toBeInTheDocument();
+  });
+
+  test("renders zero rows if data is null", async () => {
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+    axiosMock.onGet("/api/diningcommons/menuitem?id=42").reply(200, null); // data is null
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    renderWithProviders();
+    expect(
+      await screen.findByText("Reviews for Menu Item 42")
+    ).toBeInTheDocument();
+    const table = await screen.findByRole("table");
+    const rows = within(table).getAllByRole("row");
+    expect(rows.length - 1).toBe(0);
+    expect(screen.queryByText("Stryker was here")).not.toBeInTheDocument();
+    const cells = within(table).queryAllByRole("cell");
+    expect(cells.length).toBe(0);
+    expect(axiosMock.history.get.length).toBe(3);
+  });
+
+  test("does not show user or moderator action buttons", async () => {
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+    axiosMock.onGet("/api/diningcommons/menuitem?id=42").reply(200, {
+      reviews: [{ id: 1, itemId: 42, reviewerComments: "Great!" }],
+    });
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    renderWithProviders();
+    expect(
+      await screen.findByText("Reviews for Menu Item 42")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Edit" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Delete" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Approve" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Reject" })
+    ).not.toBeInTheDocument();
+  });
+
+  test("renders correct data for different itemids (query key cache test)", async () => {
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+    axiosMock.onGet("/api/diningcommons/menuitem?id=42").reply(200, {
+      reviews: [
+        {
+          id: 1,
+          itemId: 42,
+          itemsStars: 5,
+          reviewerComments: "Great!",
+          dateItemServed: "2024-01-01",
+        },
+      ],
+    });
+    axiosMock.onGet("/api/diningcommons/menuitem?id=99").reply(200, {
+      reviews: [
+        {
+          id: 2,
+          itemId: 99,
+          itemsStars: 3,
+          reviewerComments: "Meh!",
+          dateItemServed: "2024-02-01",
+        },
+      ],
+    });
+
     const queryClient = new QueryClient();
-    render(
+    // Render with itemid 42
+    const { unmount } = render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter initialEntries={["/reviews/42"]}>
           <Routes>
@@ -29,9 +202,147 @@ describe("ReviewsForMenuItemPage", () => {
             />
           </Routes>
         </MemoryRouter>
-      </QueryClientProvider>,
+      </QueryClientProvider>
     );
-    expect(screen.getByText("Reviews for Menu Item 42")).toBeInTheDocument();
-    expect(screen.getByText("Coming Soon!")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Reviews for Menu Item 42")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("ReviewTable-cell-row-0-col-itemId")
+    ).toHaveTextContent("42");
+    expect(
+      screen.getByTestId("ReviewTable-cell-row-0-col-reviewerComments")
+    ).toHaveTextContent("Great!");
+    unmount();
+    // Remount with itemid 99
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/reviews/99"]}>
+          <Routes>
+            <Route
+              path="/reviews/:itemid"
+              element={<ReviewsForMenuItemPage />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+    expect(
+      await screen.findByText("Reviews for Menu Item 99")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("ReviewTable-cell-row-0-col-itemId")
+    ).toHaveTextContent("99");
+    expect(
+      screen.getByTestId("ReviewTable-cell-row-0-col-reviewerComments")
+    ).toHaveTextContent("Meh!");
+  });
+
+  test("renders correct data for two different itemids in sequence (query key mutant)", async () => {
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+    axiosMock.onGet("/api/diningcommons/menuitem?id=101").reply(200, {
+      reviews: [
+        {
+          id: 1,
+          itemId: 101,
+          itemsStars: 5,
+          reviewerComments: "First!",
+          dateItemServed: "2024-01-01",
+        },
+      ],
+    });
+    axiosMock.onGet("/api/diningcommons/menuitem?id=202").reply(200, {
+      reviews: [
+        {
+          id: 2,
+          itemId: 202,
+          itemsStars: 3,
+          reviewerComments: "Second!",
+          dateItemServed: "2024-02-01",
+        },
+      ],
+    });
+    const queryClient = new QueryClient();
+    // Render with itemid 101
+    const { unmount } = render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/reviews/101"]}>
+          <Routes>
+            <Route
+              path="/reviews/:itemid"
+              element={<ReviewsForMenuItemPage />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+    expect(
+      await screen.findByText("Reviews for Menu Item 101")
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByTestId("ReviewTable-cell-row-0-col-itemId")
+    ).toHaveTextContent("101");
+    expect(
+      await screen.findByTestId("ReviewTable-cell-row-0-col-reviewerComments")
+    ).toHaveTextContent("First!");
+    unmount();
+    // Remount with itemid 202
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/reviews/202"]}>
+          <Routes>
+            <Route
+              path="/reviews/:itemid"
+              element={<ReviewsForMenuItemPage />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+    expect(
+      await screen.findByText("Reviews for Menu Item 202")
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByTestId("ReviewTable-cell-row-0-col-itemId")
+    ).toHaveTextContent("202");
+    expect(
+      await screen.findByTestId("ReviewTable-cell-row-0-col-reviewerComments")
+    ).toHaveTextContent("Second!");
+  });
+
+  test("renders zero rows if data is undefined (fallback array mutant)", async () => {
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+    axiosMock.onGet("/api/diningcommons/menuitem?id=303").reply(200, undefined);
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    renderWithProviders("/reviews/303");
+    expect(
+      await screen.findByText("Reviews for Menu Item 303")
+    ).toBeInTheDocument();
+    const table = screen.getByRole("table");
+    const rows = within(table).getAllByRole("row");
+    expect(rows.length - 1).toBe(0);
+  });
+
+  test("renders zero rows if reviews property is missing (fallback array mutant)", async () => {
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+    axiosMock.onGet("/api/diningcommons/menuitem?id=404").reply(200, {});
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    renderWithProviders("/reviews/404");
+    expect(
+      await screen.findByText("Reviews for Menu Item 404")
+    ).toBeInTheDocument();
+    const table = screen.getByRole("table");
+    const rows = within(table).getAllByRole("row");
+    expect(rows.length - 1).toBe(0);
   });
 });

--- a/frontend/src/tests/pages/Reviews/ReviewsForMenuItemPage.test.js
+++ b/frontend/src/tests/pages/Reviews/ReviewsForMenuItemPage.test.js
@@ -16,7 +16,7 @@ function renderWithProviders(route = "/reviews/42") {
           <Route path="/reviews/:itemid" element={<ReviewsForMenuItemPage />} />
         </Routes>
       </MemoryRouter>
-    </QueryClientProvider>
+    </QueryClientProvider>,
   );
 }
 
@@ -76,7 +76,7 @@ describe("ReviewsForMenuItemPage", () => {
       .reply(200, apiCurrentUserFixtures.userOnly);
     renderWithProviders();
     expect(
-      await screen.findByText("Reviews for Menu Item 42")
+      await screen.findByText("Reviews for Menu Item 42"),
     ).toBeInTheDocument();
     expect(await screen.findByText("Great!")).toBeInTheDocument();
     expect(await screen.findByText("Yum!")).toBeInTheDocument();
@@ -101,7 +101,7 @@ describe("ReviewsForMenuItemPage", () => {
       .reply(200, apiCurrentUserFixtures.userOnly);
     renderWithProviders();
     expect(
-      await screen.findByText("Reviews for Menu Item 42")
+      await screen.findByText("Reviews for Menu Item 42"),
     ).toBeInTheDocument();
     const table = await screen.findByRole("table");
     const rows = within(table).getAllByRole("row");
@@ -122,7 +122,7 @@ describe("ReviewsForMenuItemPage", () => {
       .reply(200, apiCurrentUserFixtures.userOnly);
     renderWithProviders();
     expect(
-      await screen.findByText("Reviews for Menu Item 42")
+      await screen.findByText("Reviews for Menu Item 42"),
     ).toBeInTheDocument();
     const table = await screen.findByRole("table");
     const rows = within(table).getAllByRole("row");
@@ -145,19 +145,19 @@ describe("ReviewsForMenuItemPage", () => {
       .reply(200, apiCurrentUserFixtures.userOnly);
     renderWithProviders();
     expect(
-      await screen.findByText("Reviews for Menu Item 42")
+      await screen.findByText("Reviews for Menu Item 42"),
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Edit" })
+      screen.queryByRole("button", { name: "Edit" }),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Delete" })
+      screen.queryByRole("button", { name: "Delete" }),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Approve" })
+      screen.queryByRole("button", { name: "Approve" }),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Reject" })
+      screen.queryByRole("button", { name: "Reject" }),
     ).not.toBeInTheDocument();
   });
 
@@ -199,16 +199,16 @@ describe("ReviewsForMenuItemPage", () => {
             />
           </Routes>
         </MemoryRouter>
-      </QueryClientProvider>
+      </QueryClientProvider>,
     );
     expect(
-      await screen.findByText("Reviews for Menu Item 42")
+      await screen.findByText("Reviews for Menu Item 42"),
     ).toBeInTheDocument();
     expect(
-      screen.getByTestId("ReviewTable-cell-row-0-col-itemId")
+      screen.getByTestId("ReviewTable-cell-row-0-col-itemId"),
     ).toHaveTextContent("42");
     expect(
-      screen.getByTestId("ReviewTable-cell-row-0-col-reviewerComments")
+      screen.getByTestId("ReviewTable-cell-row-0-col-reviewerComments"),
     ).toHaveTextContent("Great!");
     unmount();
     render(
@@ -221,16 +221,16 @@ describe("ReviewsForMenuItemPage", () => {
             />
           </Routes>
         </MemoryRouter>
-      </QueryClientProvider>
+      </QueryClientProvider>,
     );
     expect(
-      await screen.findByText("Reviews for Menu Item 99")
+      await screen.findByText("Reviews for Menu Item 99"),
     ).toBeInTheDocument();
     expect(
-      screen.getByTestId("ReviewTable-cell-row-0-col-itemId")
+      screen.getByTestId("ReviewTable-cell-row-0-col-itemId"),
     ).toHaveTextContent("99");
     expect(
-      screen.getByTestId("ReviewTable-cell-row-0-col-reviewerComments")
+      screen.getByTestId("ReviewTable-cell-row-0-col-reviewerComments"),
     ).toHaveTextContent("Meh!");
   });
 
@@ -271,16 +271,16 @@ describe("ReviewsForMenuItemPage", () => {
             />
           </Routes>
         </MemoryRouter>
-      </QueryClientProvider>
+      </QueryClientProvider>,
     );
     expect(
-      await screen.findByText("Reviews for Menu Item 101")
+      await screen.findByText("Reviews for Menu Item 101"),
     ).toBeInTheDocument();
     expect(
-      await screen.findByTestId("ReviewTable-cell-row-0-col-itemId")
+      await screen.findByTestId("ReviewTable-cell-row-0-col-itemId"),
     ).toHaveTextContent("101");
     expect(
-      await screen.findByTestId("ReviewTable-cell-row-0-col-reviewerComments")
+      await screen.findByTestId("ReviewTable-cell-row-0-col-reviewerComments"),
     ).toHaveTextContent("First!");
     unmount();
     render(
@@ -293,16 +293,16 @@ describe("ReviewsForMenuItemPage", () => {
             />
           </Routes>
         </MemoryRouter>
-      </QueryClientProvider>
+      </QueryClientProvider>,
     );
     expect(
-      await screen.findByText("Reviews for Menu Item 202")
+      await screen.findByText("Reviews for Menu Item 202"),
     ).toBeInTheDocument();
     expect(
-      await screen.findByTestId("ReviewTable-cell-row-0-col-itemId")
+      await screen.findByTestId("ReviewTable-cell-row-0-col-itemId"),
     ).toHaveTextContent("202");
     expect(
-      await screen.findByTestId("ReviewTable-cell-row-0-col-reviewerComments")
+      await screen.findByTestId("ReviewTable-cell-row-0-col-reviewerComments"),
     ).toHaveTextContent("Second!");
   });
 
@@ -316,7 +316,7 @@ describe("ReviewsForMenuItemPage", () => {
       .reply(200, apiCurrentUserFixtures.userOnly);
     renderWithProviders("/reviews/303");
     expect(
-      await screen.findByText("Reviews for Menu Item 303")
+      await screen.findByText("Reviews for Menu Item 303"),
     ).toBeInTheDocument();
     const table = screen.getByRole("table");
     const rows = within(table).getAllByRole("row");
@@ -333,7 +333,7 @@ describe("ReviewsForMenuItemPage", () => {
       .reply(200, apiCurrentUserFixtures.userOnly);
     renderWithProviders("/reviews/404");
     expect(
-      await screen.findByText("Reviews for Menu Item 404")
+      await screen.findByText("Reviews for Menu Item 404"),
     ).toBeInTheDocument();
     const table = screen.getByRole("table");
     const rows = within(table).getAllByRole("row");


### PR DESCRIPTION
# Add the individual reviews page
USER can view reviews for a menu item, the route is accessible by passing in `itemid` as a route parameter, i.e. `/reviews/{itemid}`

This page includes data about each review item with columns: id, score, date, and comments.

## Testing
Log In
https://dining-proj-j1yl.dokku-04.cs.ucsb.edu

Navigate to the route `/reviews/{itemid}`, i.e. `https://dining-proj-j1yl.dokku-04.cs.ucsb.edu/reviews/3`

The page can also be accessed with the link provided in each meal table, the link is included for each item with their respective URL mappings, see the Reviews column at https://dining-proj-j1yl.dokku-04.cs.ucsb.edu/diningcommons/2025-05-23/carrillo/breakfast

## Deployment
https://dining-proj-j1yl.dokku-04.cs.ucsb.edu/reviews/3

## Chromatic
![image](https://github.com/user-attachments/assets/8f0346f6-bf5f-4253-88c2-055736c03659)

https://6823eb9968d1fc42e6c7bf71-ibikhdzmmz.chromatic.com/?path=/docs/pages-reviews-reviewsformenuitempage--docs